### PR TITLE
Remove restriction on package_ensure and conditionally require puppetlabs-products repo

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,5 +6,8 @@ fixtures:
     'common':
       repo: 'git://github.com/ghoneycutt/puppet-module-common.git'
       ref: 'v1.0.2'
+    'puppetlabs_yum':
+      repo: 'git://github.com/stahnma/puppet-module-puppetlabs_yum.git'
+      ref: '0.0.14'
   symlinks:
     facter: "#{source_dir}"

--- a/Modulefile
+++ b/Modulefile
@@ -9,3 +9,4 @@ project_page 'https://github.com/ghoneycutt/puppet-module-facter'
 
 dependency 'puppetlabs/stdlib', '>= 3.2.0'
 dependency 'ghoneycutt/common', '>= 1.0.0'
+dependency 'stahnma/puppetlabs_yum', '>= 0.1.0'

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This module is built for use with Puppet v3 and supports Ruby v1.8.7, v1.9.3, v2
 # Parameters
 ------------
 
+manage\_puppetlabs\_repo
+--------------
+Boolean to manage the Puppetlabs repo.  This only effects RedHat based systems.
+
+- *Default*: false
+
 manage_package
 --------------
 Boolean to manage the package resource.
@@ -30,7 +36,7 @@ String or Array of package(s) for facter.
 
 package_ensure
 --------------
-String for ensure parameter to facter package. Valid values are 'present' and 'absent'.
+String for ensure parameter to facter package.
 
 - *Default*: present
 

--- a/metadata.json
+++ b/metadata.json
@@ -60,6 +60,10 @@
     {
       "name": "ghoneycutt/common",
       "version_requirement": ">= 1.0.0"
+    },
+    {
+      "name": "stahnma/puppetlabs_yum",
+      "version_requirement": ">= 0.1.0"
     }
   ],
   "types": [


### PR DESCRIPTION
- Allow package_ensure to be any value to match allowed values for Package type and to allow specifying specific versions
- Add manage_puppetlabs_repo parameter to conditionally require Yumrepo[puppetlabs-products] before installing facter
- Added dependency for module stahnma/puppetlabs_yum

This is likely not best way to handle the dependency on the puppetlabs repo, but the removal of restriction on values for `package_ensure` would be very useful to ensure specific versions are installed across servers.
