### PR TITLE
Allow package_ensure to be any value

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ String or Array of package(s) for facter.
 
 package_ensure
 --------------
-String for ensure parameter to facter package. Valid values are 'present' and 'absent'.
+String for ensure parameter to facter package.
 
 - *Default*: present
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,10 +16,7 @@ class facter (
   $ensure_facter_symlink  = false,
 ) {
 
-  validate_re($package_ensure,
-    '^(present)|(absent)$',
-    "facter::package_ensure must be \'present\' or \'absent\'. Detected value is <${package_ensure}>."
-  )
+  validate_string($package_ensure)
 
   validate_absolute_path($facts_d_dir)
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -250,12 +250,12 @@ describe 'facter' do
 
   context 'with invalid package_ensure param' do
     let(:facts) { { :osfamily => 'RedHat' } }
-    let(:params) { { :package_ensure => 'invalid' } }
+    let(:params) { { :package_ensure => ['present'] } }
 
     it do
       expect {
         should contain_class('facter')
-      }.to raise_error(Puppet::Error,/facter::package_ensure must be \'present\' or \'absent\'. Detected value is <invalid>./)
+      }.to raise_error(Puppet::Error)
     end
   end
 


### PR DESCRIPTION
The use case for this is ensuring a specific version of facter is installed across all systems.

Originally part of #15
