### PR TITLE
Use concat to build facts file

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   repositories:
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '4.6.0'
+      ref: '4.22.0'
   symlinks:
     facter: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,8 @@ fixtures:
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
       ref: '4.22.0'
+    concat:
+      repo: 'https://github.com/puppetlabs/puppetlabs-concat.git'
+      ref: '4.0.0'
   symlinks:
     facter: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,27 +15,11 @@ before_install:
 
 sudo: false
 
-script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
+script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec strings:generate'
 
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4"
   - rvm: 2.4.1

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'puppet-lint-unquoted_string-check', :require => false
 gem 'puppet-lint-variable_contains_upcase', :require => false
 
 gem 'rspec',     '~> 2.0', :require => false          if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'rspec-puppet-facts', :require => false
 gem 'rake',      '~> 10.0', :require => false         if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 gem 'json',      '<= 1.8', :require => false          if RUBY_VERSION < '2.0.0'
 gem 'json_pure', '<= 2.0.1', :require => false        if RUBY_VERSION < '2.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,7 @@ gem 'metadata-json-lint' if RUBY_VERSION >= '2.0'
 gem 'puppetlabs_spec_helper', '2.0.2',    :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false if RUBY_VERSION >= '1.9'
 gem 'parallel_tests',         '<= 2.9.0', :require => false if RUBY_VERSION < '2.0.0'
+
+group :documentation do
+  gem 'puppet-strings', require: false
+end

--- a/Rakefile
+++ b/Rakefile
@@ -3,14 +3,24 @@ require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.relative = true
-PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp', 'vendor/**/*.pp']
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vendor/**/*.pp"]
 
-desc 'Validate manifests, templates, ruby files and shell scripts'
+desc 'Validate manifests, templates, and ruby files'
 task :validate do
-  Dir['spec/**/*.rb', 'lib/**/*.rb'].each do |ruby_file|
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
     sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
   end
-  Dir['files/**/*.sh'].each do |shell_script|
-    sh "bash -n #{shell_script}"
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
   end
 end
+
+# Puppet Strings (Documentation generation from inline comments)
+# See: https://github.com/puppetlabs/puppet-strings#rake-tasks
+require 'puppet-strings/tasks'
+
+desc 'Alias for strings:generate'
+task :doc => ['strings:generate']

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,25 @@
+---
+facter::manage_facts_d_dir: true
+facter::purge_facts_d: false
+facter::facts_d_dir: /etc/facter/facts.d
+facter::facts_d_owner: root
+facter::facts_d_group: root
+facter::facts_d_mode: '0755'
+facter::path_to_facter: /opt/puppetlabs/bin/facter
+facter::path_to_facter_symlink: /usr/local/bin/facter
+facter::ensure_facter_symlink: false
+facter::facts_hash: {}
+facter::facts_hash_hiera_merge: false
+facter::facts_file: facts.txt
+facter::facts_file_owner: root
+facter::facts_file_group: root
+facter::facts_file_mode: '0644'
+facter::facter_conf_dir: /etc/puppetlabs/facter
+facter::facter_conf_dir_owner: root
+facter::facter_conf_dir_group: root
+facter::facter_conf_dir_mode: '0755'
+facter::facter_conf_name: facter.conf
+facter::facter_conf_owner: root
+facter::facter_conf_group: root
+facter::facter_conf_mode: '0644'
+facter::facter_conf: {}

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -1,0 +1,12 @@
+---
+facter::facts_d_dir: C:\ProgramData\PuppetLabs\facter\facts.d
+facter::facts_d_owner: NT AUTHORITY\SYSTEM
+facter::facts_d_group: NT AUTHORITY\SYSTEM
+facter::path_to_facter: C:\Program Files\Puppet Labs\Puppet\bin\facter.bat
+facter::facts_file_owner: NT AUTHORITY\SYSTEM
+facter::facts_file_group: NT AUTHORITY\SYSTEM
+facter::facter_conf_dir: C:\ProgramData\PuppetLabs\facter\etc
+facter::facter_conf_dir_owner: NT AUTHORITY\SYSTEM
+facter::facter_conf_dir_group: NT AUTHORITY\SYSTEM
+facter::facter_conf_owner: NT AUTHORITY\SYSTEM
+facter::facter_conf_group: NT AUTHORITY\SYSTEM

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,10 @@
+---
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+hierarchy:
+  - name: "OS family"
+    path: "os/%{facts.os.family}.yaml"
+  - name: "common"
+    path: "common.yaml"

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -6,17 +6,25 @@ define facter::fact (
   $value,
   String $fact                    = $name,
   String $file                    = 'facts.txt',
-  Stdlib::Absolutepath $facts_dir = '/etc/facter/facts.d',
+  Optional[Stdlib::Absolutepath] $facts_dir = undef,
 ) {
 
   include ::facter
+
+  $facts_dir_path = pick($facts_dir, $::facter::facts_d_dir)
+
+  if $facts['os']['family'] == 'windows' {
+    $facts_file_path = "${facts_dir_path}\\${file}"
+  } else {
+    $facts_file_path = "${facts_dir_path}/${file}"
+  }
 
   $match = "^${name}=\\S*$"
 
   if $file != $facter::facts_file {
     file { "facts_file_${name}":
       ensure => file,
-      path   => "${facts_dir}/${file}",
+      path   => $facts_file_path,
       owner  => $facter::facts_file_owner,
       group  => $facter::facts_file_group,
       mode   => $facter::facts_file_mode,
@@ -24,7 +32,7 @@ define facter::fact (
   }
 
   file_line { "fact_line_${name}":
-    path  => "${facts_dir}/${file}",
+    path  => $facts_file_path,
     line  => "${name}=${value}",
     match => $match,
   }

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -4,9 +4,9 @@
 #
 define facter::fact (
   $value,
-  $fact      = $name,
-  $file      = 'facts.txt',
-  $facts_dir = '/etc/facter/facts.d',
+  String $fact                    = $name,
+  String $file                    = 'facts.txt',
+  Stdlib::Absolutepath $facts_dir = '/etc/facter/facts.d',
 ) {
 
   include ::facter

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,81 +3,24 @@
 # Manage facter
 #
 class facter (
-  $manage_package         = undef,
-  $package_name           = 'facter',
-  $package_ensure         = 'present',
-  $manage_facts_d_dir     = true,
-  $purge_facts_d          = false,
-  $facts_d_dir            = '/etc/facter/facts.d',
-  $facts_d_owner          = 'root',
-  $facts_d_group          = 'root',
-  $facts_d_mode           = '0755',
-  $path_to_facter         = '/usr/bin/facter',
-  $path_to_facter_symlink = '/usr/local/bin/facter',
-  $ensure_facter_symlink  = false,
-  $facts_hash             = {},
-  $facts_hash_hiera_merge = false,
-  $facts_file             = 'facts.txt',
-  $facts_file_owner       = 'root',
-  $facts_file_group       = 'root',
-  $facts_file_mode        = '0644',
+  Boolean $manage_facts_d_dir                   = true,
+  Boolean $purge_facts_d                        = false,
+  Stdlib::Absolutepath $facts_d_dir             = '/etc/facter/facts.d',
+  String $facts_d_owner                         = 'root',
+  String $facts_d_group                         = 'root',
+  Stdlib::Filemode $facts_d_mode                = '0755',
+  Stdlib::Absolutepath $path_to_facter          = '/opt/puppetlabs/bin/facter',
+  Stdlib::Absolutepath $path_to_facter_symlink  = '/usr/local/bin/facter',
+  Boolean $ensure_facter_symlink                = false,
+  Hash $facts_hash                              = {},
+  Boolean $facts_hash_hiera_merge               = false,
+  String $facts_file                            = 'facts.txt',
+  String $facts_file_owner                      = 'root',
+  String $facts_file_group                      = 'root',
+  Stdlib::Filemode $facts_file_mode             = '0644',
 ) {
 
-  validate_string($package_ensure)
-
-  validate_absolute_path($facts_d_dir)
-
-  validate_re($facts_d_mode,
-    '^\d{4}$',
-    "facter::facts_d_mode must be a four digit mode. Detected value is <${facts_d_mode}>."
-  )
-
-  # validate params
-  validate_absolute_path($path_to_facter_symlink)
-  validate_absolute_path($path_to_facter)
-
-  if versioncmp($::puppetversion, '4.0.0') >= 0 {
-    $manage_package_real = false
-  } elsif $manage_package == undef {
-    $manage_package_real = true
-  } else {
-    $manage_package_real = $manage_package
-  }
-
-  if is_string($manage_package_real) {
-    $manage_package_bool = str2bool($manage_package_real)
-  } else {
-    $manage_package_bool = $manage_package_real
-    validate_bool($manage_package_bool)
-  }
-
-  if is_string($manage_facts_d_dir) {
-    $manage_facts_d_dir_real = str2bool($manage_facts_d_dir)
-  } else {
-    validate_bool($manage_facts_d_dir)
-    $manage_facts_d_dir_real = $manage_facts_d_dir
-  }
-
-  if is_string($purge_facts_d) {
-    $purge_facts_d_real = str2bool($purge_facts_d)
-  } else {
-    $purge_facts_d_real = $purge_facts_d
-  }
-  validate_bool($purge_facts_d_real)
-
-  if !is_string($package_name) and !is_array($package_name) {
-    fail('facter::package_name must be a string or an array.')
-  }
-
-  if $manage_package_bool == true {
-
-    package { $package_name:
-      ensure => $package_ensure,
-    }
-  }
-
-  if $manage_facts_d_dir_real == true {
-
+  if $manage_facts_d_dir == true {
     exec { "mkdir_p-${facts_d_dir}":
       command => "mkdir -p ${facts_d_dir}",
       unless  => "test -d ${facts_d_dir}",
@@ -90,22 +33,14 @@ class facter (
       owner   => $facts_d_owner,
       group   => $facts_d_group,
       mode    => $facts_d_mode,
-      purge   => $purge_facts_d_real,
-      recurse => $purge_facts_d_real,
+      purge   => $purge_facts_d,
+      recurse => $purge_facts_d,
       require => Exec["mkdir_p-${facts_d_dir}"],
     }
   }
 
-  if is_string($ensure_facter_symlink) {
-    $ensure_facter_symlink_bool = str2bool($ensure_facter_symlink)
-  } else {
-    $ensure_facter_symlink_bool = $ensure_facter_symlink
-  }
-  validate_bool($ensure_facter_symlink_bool)
-
   # optionally create symlinks to facter binary
-  if $ensure_facter_symlink_bool == true {
-
+  if $ensure_facter_symlink == true {
     file { 'facter_symlink':
       ensure => 'link',
       path   => $path_to_facter_symlink,
@@ -113,7 +48,6 @@ class facter (
     }
   }
 
-  validate_absolute_path("${facts_d_dir}/${facts_file}")
   file { 'facts_file':
     ensure => file,
     path   => "${facts_d_dir}/${facts_file}",
@@ -122,21 +56,12 @@ class facter (
     mode   => $facts_file_mode,
   }
 
-  # optionally push fact to client
-  if is_string($facts_hash_hiera_merge) {
-    $facts_hash_hiera_merge_real = str2bool($facts_hash_hiera_merge)
-  } else {
-    $facts_hash_hiera_merge_real = $facts_hash_hiera_merge
-  }
-  validate_bool($facts_hash_hiera_merge_real)
-
-  if $facts_hash_hiera_merge_real == true {
+  if $facts_hash_hiera_merge == true {
     $facts_hash_real = hiera_hash('facter::facts_hash', {})
   } else {
     $facts_hash_real = $facts_hash
   }
 
-  validate_hash($facts_hash_real)
   if ! empty( $facts_hash_real ) {
     $facts_defaults = {
       'file'      => $facts_file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class facter (
   String $facts_file_owner                      = 'root',
   String $facts_file_group                      = 'root',
   Stdlib::Filemode $facts_file_mode             = '0644',
+  Boolean $purge_facts                          = false,
   Stdlib::Absolutepath $facter_conf_dir         = '/etc/puppetlabs/facter',
   String $facter_conf_dir_owner                 = 'root',
   String $facter_conf_dir_group                 = 'root',
@@ -81,12 +82,24 @@ class facter (
     }
   }
 
-  file { 'facts_file':
-    ensure => file,
-    path   => $facts_file_path,
-    owner  => $facts_file_owner,
-    group  => $facts_file_group,
-    mode   => $facts_file_mode_real,
+  if $purge_facts {
+    concat { 'facts_file':
+      ensure         => 'present',
+      path           => "${facts_d_dir}/${facts_file}",
+      owner          => $facts_file_owner,
+      group          => $facts_file_group,
+      mode           => $facts_file_mode,
+      ensure_newline => true,
+      require        => File['facts_d_directory'],
+    }
+  } else {
+    file { 'facts_file':
+      ensure => file,
+      path   => $facts_file_path,
+      owner  => $facts_file_owner,
+      group  => $facts_file_group,
+      mode   => $facts_file_mode_real,
+    }
   }
 
   if $facts_hash_hiera_merge == true {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,15 @@ class facter (
   String $facts_file_owner                      = 'root',
   String $facts_file_group                      = 'root',
   Stdlib::Filemode $facts_file_mode             = '0644',
+  Stdlib::Absolutepath $facter_conf_dir         = '/etc/puppetlabs/facter',
+  String $facter_conf_dir_owner                 = 'root',
+  String $facter_conf_dir_group                 = 'root',
+  Stdlib::Filemode $facter_conf_dir_mode        = '0755',
+  String $facter_conf_name                      = 'facter.conf',
+  String $facter_conf_owner                     = 'root',
+  String $facter_conf_group                     = 'root',
+  Stdlib::Filemode $facter_conf_mode            = '0644',
+  Facter::Conf $facter_conf                     = {},
 ) {
 
   if $manage_facts_d_dir == true {
@@ -69,4 +78,30 @@ class facter (
     }
     create_resources('facter::fact',$facts_hash_real, $facts_defaults)
   }
+
+  exec { "mkdir_p-${facter_conf_dir}":
+    command => "mkdir -p ${facter_conf_dir}",
+    unless  => "test -d ${facter_conf_dir}",
+    path    => '/bin:/usr/bin',
+  }
+  file { $facter_conf_dir:
+    ensure  => 'directory',
+    owner   => $facter_conf_dir_owner,
+    group   => $facter_conf_dir_group,
+    mode    => $facter_conf_dir_mode,
+    require => Exec["mkdir_p-${facter_conf_dir}"],
+  }
+
+  if ! empty($facter_conf) {
+    # Template uses:
+    # - $facter_conf
+    file { "${facter_conf_dir}/${facter_conf_name}":
+      ensure  => 'file',
+      owner   => $facter_conf_owner,
+      group   => $facter_conf_group,
+      mode    => $facter_conf_mode,
+      content => template('facter/facter.conf.erb'),
+    }
+  }
+
 }

--- a/metadata.json
+++ b/metadata.json
@@ -45,6 +45,9 @@
     },
     {
       "operatingsystem": "Ubuntu"
+    },
+    {
+      "operatingsystem": "windows"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,10 +10,10 @@
   "issues_url": "https://github.com/ghoneycutt/puppet-module-facter/issues",
   "description": "Manage Facter and optionally ensure facts.d directory.",
   "requirements": [
-    {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0"}
+    {"name":"puppet","version_requirement":">= 4.7.0 < 7.0.0"}
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.22.0 < 6.0.0"}
   ],
   "operatingsystem_support": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -49,5 +49,9 @@
     {
       "operatingsystem": "windows"
     }
+  ],
+  "dependencies": [
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"},
+    {"name":"puppetlabs/concat","version_requirement":">= 4.0.0 < 7.0.0"}
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,13 +8,6 @@ describe 'facter' do
 
     it { should contain_class('facter') }
 
-    it {
-      should contain_package('facter').with({
-        'ensure' => 'present',
-        'name'   => 'facter',
-      })
-    }
-
     it { should contain_file('facts_file').with({
         'ensure'  => 'file',
         'path'    => '/etc/facter/facts.d/facts.txt',
@@ -46,148 +39,45 @@ describe 'facter' do
   end
 
   describe 'with purge_facts_d' do
-    ['true',true].each do |value|
-      context "set to #{value}" do
-        let(:params) { { :purge_facts_d => value } }
-        let(:facts) { { :osfamily => 'RedHat' } }
+    context "set to true" do
+      let(:params) { { :purge_facts_d => true } }
+      let(:facts) { { :osfamily => 'RedHat' } }
 
-        it {
-          should contain_file('facts_d_directory').with({
-            'ensure'  => 'directory',
-            'path'    => '/etc/facter/facts.d',
-            'owner'   => 'root',
-            'group'   => 'root',
-            'mode'    => '0755',
-            'purge'   => true,
-            'recurse' => true,
-            'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
-          })
-        }
-      end
+      it {
+        should contain_file('facts_d_directory').with({
+          'ensure'  => 'directory',
+          'path'    => '/etc/facter/facts.d',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0755',
+          'purge'   => true,
+          'recurse' => true,
+          'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
+        })
+      }
     end
-    ['false',false].each do |value|
-      context "set to #{value}" do
-        let(:params) { { :purge_facts_d => value } }
-        let(:facts) { { :osfamily => 'RedHat' } }
+    context "set to false" do
+      let(:params) { { :purge_facts_d => false } }
+      let(:facts) { { :osfamily => 'RedHat' } }
 
-        it {
-          should contain_file('facts_d_directory').with({
-            'ensure'  => 'directory',
-            'path'    => '/etc/facter/facts.d',
-            'owner'   => 'root',
-            'group'   => 'root',
-            'mode'    => '0755',
-            'purge'   => false,
-            'recurse' => false,
-            'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
-          })
-        }
-      end
-    end
-    context 'set to an invalid type' do
-      let(:params) { { :purge_facts_d => ['invalid', 'type'] } }
-
-      it do
-        expect {
-          should contain_class('facter')
-        }.to raise_error(Puppet::Error,/\["invalid", "type"\] is not a boolean/)
-      end
+      it {
+        should contain_file('facts_d_directory').with({
+          'ensure'  => 'directory',
+          'path'    => '/etc/facter/facts.d',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0755',
+          'purge'   => false,
+          'recurse' => false,
+          'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
+        })
+      }
     end
   end
 
-  describe 'on puppet5 the package should not be managed' do
-    let(:facts) { { :puppetversion => '5.3.0' } }
-    [true,false].each do |value|
-      context "with manage_package set to #{value}" do
-        let(:params) { { :manage_package => value } }
-
-        it { should_not contain_package('facter') }
-      end
-    end
-  end
-
-  describe 'on puppet4 the package should not be managed' do
-    let(:facts) { { :puppetversion => '4.10.0' } }
-    [true,false].each do |value|
-      context "with manage_package set to #{value}" do
-        let(:params) { { :manage_package => value } }
-
-        it { should_not contain_package('facter') }
-      end
-    end
-  end
-
-  context 'with default options and stringified \'true\' for manage_package param' do
-    let(:params) { { :manage_package => 'true' } }
-    let(:facts) { { :osfamily => 'RedHat' } }
-
-    it { should contain_class('facter') }
-
-    it {
-      should contain_package('facter').with({
-        'ensure' => 'present',
-        'name'   => 'facter',
-      })
-    }
-
-    it {
-      should contain_file('facts_d_directory').with({
-        'ensure'  => 'directory',
-        'path'    => '/etc/facter/facts.d',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0755',
-        'purge'   => false,
-        'recurse' => false,
-        'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
-      })
-    }
-
-    it {
-      should contain_exec('mkdir_p-/etc/facter/facts.d').with({
-        'command' => 'mkdir -p /etc/facter/facts.d',
-        'unless'  => 'test -d /etc/facter/facts.d',
-      })
-    }
-  end
-
-  context 'with default options and stringified \'true\' for manage_facts_d_dir param' do
-    let(:params) { { :manage_facts_d_dir => 'true' } }
-    let(:facts) { { :osfamily => 'RedHat' } }
-
-    it { should contain_class('facter') }
-
-    it {
-      should contain_package('facter').with({
-        'ensure' => 'present',
-        'name'   => 'facter',
-      })
-    }
-
-    it {
-      should contain_file('facts_d_directory').with({
-        'ensure'  => 'directory',
-        'path'    => '/etc/facter/facts.d',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0755',
-        'purge'   => false,
-        'recurse' => false,
-        'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
-      })
-    }
-
-    it {
-      should contain_exec('mkdir_p-/etc/facter/facts.d').with({
-        'command' => 'mkdir -p /etc/facter/facts.d',
-        'unless'  => 'test -d /etc/facter/facts.d',
-      })
-    }
-  end
-
-  context 'with default options with manage_package = true and manage_facts_d_dir = false' do
+  context 'with manage_facts_d_dir = false' do
     let(:params) do
-      { :manage_package     => true,
+      {
         :manage_facts_d_dir => false,
       }
     end
@@ -195,29 +85,20 @@ describe 'facter' do
 
     it { should contain_class('facter') }
 
-    it {
-      should contain_package('facter').with({
-        'ensure' => 'present',
-        'name'   => 'facter',
-      })
-    }
-
     it { should_not contain_file('facts_d_directory') }
 
     it { should_not contain_exec('mkdir_p-/etc/facter/facts.d') }
   end
 
-  context 'with default options with manage_package = false and manage_facts_d_dir = true' do
+  context 'with manage_facts_d_dir = true' do
     let(:params) do
-      { :manage_package     => false,
+      {
         :manage_facts_d_dir => true,
       }
     end
     let(:facts) { { :osfamily => 'RedHat' } }
 
     it { should contain_class('facter') }
-
-    it { should_not contain_package('facter') }
 
     it {
       should contain_file('facts_d_directory').with({
@@ -236,23 +117,6 @@ describe 'facter' do
         'unless'  => 'test -d /etc/facter/facts.d',
       })
     }
-  end
-
-  context 'with default options with manage_package = false and manage_facts_d_dir = false' do
-    let(:params) do
-      { :manage_package     => false,
-        :manage_facts_d_dir => false,
-      }
-    end
-    let(:facts) { { :osfamily => 'RedHat' } }
-
-    it { should contain_class('facter') }
-
-    it { should_not contain_package('facter') }
-
-    it { should_not contain_file('facts_d_directory') }
-
-    it { should_not contain_exec('mkdir_p-/etc/facter/facts.d') }
   end
 
   context 'with facts specified as a hash on RedHat' do
@@ -369,8 +233,7 @@ describe 'facter' do
   context 'with all options specified' do
     let(:facts) { { :osfamily => 'RedHat' } }
     let(:params) do
-      { :package_name     => 'myfacter',
-        :package_ensure   => 'absent',
+      {
         :facts_d_dir      => '/etc/puppet/facter/facts.d',
         :facts_d_owner    => 'puppet',
         :facts_d_group    => 'puppet',
@@ -388,12 +251,6 @@ describe 'facter' do
     end
 
     it { should contain_class('facter') }
-
-    it {
-      should contain_package('myfacter').with({
-        'ensure' => 'absent',
-      })
-    }
 
     it {
       should contain_file('facts_d_directory').with({
@@ -431,73 +288,6 @@ describe 'facter' do
     }
   end
 
-  describe 'with package_name set to' do
-    context 'a string' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :package_name => 'myfacter' } }
-
-      it {
-        should contain_package('myfacter').with({
-          'ensure' => 'present',
-        })
-      }
-    end
-
-    context 'an array' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :package_name => ['facter','facterfoo'] } }
-
-      it {
-        should contain_package('facter').with({
-          'ensure' => 'present',
-        })
-      }
-
-      it {
-        should contain_package('facterfoo').with({
-          'ensure' => 'present',
-        })
-      }
-    end
-
-    context 'an invalid type (boolean)' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :package_name => true } }
-
-      it do
-        expect {
-          should contain_class('facter')
-        }.to raise_error(Puppet::Error,/facter::package_name must be a string or an array./)
-      end
-    end
-  end
-
-  describe 'with package_ensure parameter' do
-    ['present','absent','23'].each do |value|
-      context "set to a valid string value of #{value}" do
-        let(:facts) { { :osfamily => 'RedHat' } }
-        let(:params) { { :package_ensure => value } }
-
-        it {
-          should contain_package('facter').with({
-            'ensure' => value,
-          })
-        }
-      end
-    end
-
-    context 'set to a non-string value' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :package_ensure => ['invalid'] } }
-
-      it do
-        expect {
-          should contain_class('facter')
-        }.to raise_error(Puppet::Error)
-      end
-    end
-  end
-
   context 'with invalid facts_d_dir param' do
     let(:facts) { { :osfamily => 'RedHat' } }
     let(:params) { { :facts_d_dir => 'invalid/path/statement' } }
@@ -516,7 +306,7 @@ describe 'facter' do
     it do
       expect {
         should contain_class('facter')
-      }.to raise_error(Puppet::Error,/facter::facts_d_mode must be a four digit mode. Detected value is <751>./)
+      }.to raise_error(Puppet::Error,/Pattern\[\/\^\[0124\]\{1\}\[0-7\]\{3\}\$\/\]/)
     end
   end
 
@@ -543,28 +333,24 @@ describe 'facter' do
   end
 
   describe 'with ensure_facter_symlink' do
-    ['true',true].each do |value|
-      context "set to #{value} (default)" do
-        let(:facts) { { :osfamily => 'Debian' } }
-        let(:params) { { :ensure_facter_symlink => value } }
+    context "set to true (default)" do
+      let(:facts) { { :osfamily => 'Debian' } }
+      let(:params) { { :ensure_facter_symlink => true } }
 
-        it {
-          should contain_file('facter_symlink').with({
-            'ensure'  => 'link',
-            'path'    => '/usr/local/bin/facter',
-            'target'  => '/usr/bin/facter',
-          })
-        }
-      end
+      it {
+        should contain_file('facter_symlink').with({
+          'ensure'  => 'link',
+          'path'    => '/usr/local/bin/facter',
+          'target'  => '/opt/puppetlabs/bin/facter',
+        })
+      }
     end
 
-    ['false',false].each do |value|
-      context "set to #{value} (default)" do
-        let(:facts) { { :osfamily => 'Debian' } }
-        let(:params) { { :ensure_facter_symlink => value } }
+    context "set to false (default)" do
+      let(:facts) { { :osfamily => 'Debian' } }
+      let(:params) { { :ensure_facter_symlink => false } }
 
-        it { should_not contain_file('facter_symlink') }
-      end
+      it { should_not contain_file('facter_symlink') }
     end
 
     context 'enabled with all params specified' do
@@ -706,11 +492,11 @@ describe 'facter' do
     end
 
     validations = {
-      'bool_stringified' => {
-        :name    => %w(facts_hash_hiera_merge),
-        :valid   => [true, 'true', false, 'false'],
-        :invalid => ['invalid', 3, 2.42, %w(array), { 'ha' => 'sh' }, nil],
-        :message => '(is not a boolean|Unknown type of boolean)',
+      'boolean' => {
+        :name    => %w(facts_hash_hiera_merge purge_facts_d),
+        :valid   => [true, false],
+        :invalid => ['invalid', 'true', 'false', 3, 2.42, %w(array), { 'ha' => 'sh' }, nil],
+        :message => 'expects a Boolean value',
       },
     }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,6 +16,8 @@ describe 'facter' do
       })
     }
 
+    it { should_not contain_concat('facts_file') }
+
     it {
       should contain_file('facts_d_directory').with({
         'ensure'  => 'directory',
@@ -54,6 +56,23 @@ describe 'facter' do
     }
 
     it { should_not contain_file('/etc/puppetlabs/facter/facter.conf') }
+  end
+
+  context 'with purge_facts => true' do
+    let(:facts) { { :os => { :family => 'RedHat' } } }
+    let(:params) {{ :purge_facts => true }}
+
+    it { should_not contain_file('facts_file') }
+    it { should contain_concat('facts_file').with({
+        'ensure'          => 'present',
+        'path'            => '/etc/facter/facts.d/facts.txt',
+        'owner'           => 'root',
+        'group'           => 'root',
+        'mode'            => '0644',
+        'ensure_newline'  => 'true',
+        'require'         => 'File[facts_d_directory]',
+      })
+    }
   end
 
   on_supported_os({

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -36,6 +36,25 @@ describe 'facter' do
         'unless'  => 'test -d /etc/facter/facts.d',
       })
     }
+
+    it {
+      should contain_exec('mkdir_p-/etc/puppetlabs/facter').with({
+        'command' => 'mkdir -p /etc/puppetlabs/facter',
+        'unless'  => 'test -d /etc/puppetlabs/facter',
+      })
+    }
+
+    it {
+      should contain_file('/etc/puppetlabs/facter').with({
+        'ensure'  => 'directory',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0755',
+        'require' => 'Exec[mkdir_p-/etc/puppetlabs/facter]',
+      })
+    }
+
+    it { should_not contain_file('/etc/puppetlabs/facter/facter.conf') }
   end
 
   describe 'with purge_facts_d' do
@@ -246,7 +265,10 @@ describe 'facter' do
           'fact' => {
             'value' => 'value',
           },
-        }
+        },
+        :facter_conf => {
+          'global' => { 'external-dir' => ['/foo'] },
+        },
       }
     end
 
@@ -284,6 +306,41 @@ describe 'facter' do
     it {
       should contain_file_line('fact_line_fact').with({
         'line' => 'fact=value',
+      })
+    }
+
+    it {
+      should contain_exec('mkdir_p-/etc/puppetlabs/facter').with({
+        'command' => 'mkdir -p /etc/puppetlabs/facter',
+        'unless'  => 'test -d /etc/puppetlabs/facter',
+      })
+    }
+
+    it {
+      should contain_file('/etc/puppetlabs/facter').with({
+        'ensure'  => 'directory',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0755',
+        'require' => 'Exec[mkdir_p-/etc/puppetlabs/facter]',
+      })
+    }
+
+    it {
+      should contain_file('/etc/puppetlabs/facter/facter.conf').with({
+        'ensure' => 'file',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0644',
+        'content' => '# File managed by Puppet, do not edit
+{
+  "global": {
+    "external-dir": [
+      "/foo"
+    ]
+  }
+}
+'
       })
     }
   end

--- a/spec/defines/fact_spec.rb
+++ b/spec/defines/fact_spec.rb
@@ -31,6 +31,33 @@ describe 'facter::fact' do
         'match' => '^fact1=\S*$',
       })
     }
+
+    context 'when facter::purge_facts => true' do
+      let(:pre_condition) do
+        "class { 'facter': purge_facts => true }"
+      end
+
+      it { should_not contain_file('facts_file_fact1') }
+      it { should_not contain_file_line('fact_line_fact1') }
+      it {
+        should contain_concat('facts_file_fact1').with({
+          'ensure'          => 'present',
+          'path'            => '/factsdir/custom.txt',
+          'owner'           => 'root',
+          'group'           => 'root',
+          'mode'            => '0644',
+          'ensure_newline'  => 'true',
+          'require'         => 'File[facts_d_directory]',
+        })
+      }
+
+      it {
+        should contain_concat__fragment('fact_line_fact1').with({
+          'target'  => '/factsdir/custom.txt',
+          'content' => 'fact1=fact1value',
+        })
+      }
+    end
   end
 
   context 'with fact specified ' do

--- a/spec/defines/fact_spec.rb
+++ b/spec/defines/fact_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 describe 'facter::fact' do
+  let(:facts) { { :os => { :family => 'RedHat' } } }
 
   context 'with fact and facts_dir specified' do
     let(:title) { 'fact1' }
@@ -52,5 +53,35 @@ describe 'facter::fact' do
         'path' => '/etc/facter/facts.d/facts.txt',
       })
     }
+  end
+
+  on_supported_os({
+    :supported_os => [
+      {
+        "operatingsystem" => "windows",
+        "operatingsystemrelease" => ["2012 R2"],
+      }
+    ]
+  }).each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      let(:title) { 'fact2' }
+      let(:params) do
+        {
+          :fact => 'fact2',
+          :value => 'fact2value',
+        }
+      end
+
+      it { should_not contain_file('facts_file_fact2') }
+
+      it {
+        should contain_file_line('fact_line_fact2').with({
+          'name' => 'fact_line_fact2',
+          'line' => 'fact2=fact2value',
+          'path' => 'C:\ProgramData\PuppetLabs\facter\facts.d\facts.txt',
+        })
+      }
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,9 @@ RSpec.configure do |c|
 end
 
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+
+include RspecPuppetFacts
 
 RSpec.configure do |config|
   config.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
@@ -18,6 +21,5 @@ RSpec.configure do |config|
     :environment     => 'rp_env',
     :parameter_tests => 'fix_for_hiera_v2_with_puppet_v4.0-4.2',
     :fqdn            => 'hiera2.fix',
-    :puppetversion   => '3.8.0',
   }
 end

--- a/templates/facter.conf.erb
+++ b/templates/facter.conf.erb
@@ -1,0 +1,4 @@
+# File managed by Puppet, do not edit
+<%- if @facter_conf -%>
+<%= JSON.pretty_generate(@facter_conf) %>
+<%- end -%>

--- a/types/conf.pp
+++ b/types/conf.pp
@@ -1,0 +1,19 @@
+#
+type Facter::Conf = Struct[{'facts'  => Optional[Struct[{
+                                          'blocklist' => Optional[Array[String]],
+                                          'ttls'      => Optional[Array[Hash]]
+                                          }]],
+                            'global' => Optional[Struct[{
+                                          'external-dir'      => Optional[Array[Stdlib::Absolutepath]],
+                                          'custom-dir'        => Optional[Array[Stdlib::Absolutepath]],
+                                          'no-external-facts' => Optional[Boolean],
+                                          'no-custom-facts'   => Optional[Boolean],
+                                          'no-ruby'           => Optional[Boolean]
+                                          }]],
+                            'cli'    => Optional[Struct[{
+                                          'debug'     => Optional[Boolean],
+                                          'trace'     => Optional[Boolean],
+                                          'verbose'   => Optional[Boolean],
+                                          'log-level' => Optional[Boolean]
+                                          }]]
+                          }]


### PR DESCRIPTION
Right now if I define a facter::fact and then remove it from catalog, the fact is left behind in facts file.  This would ensure facts file only contains facts put in place by Puppet.
