### PR TITLE
Adding Support For Windows 

### DIFF
--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -6,7 +6,7 @@ define facter::fact (
   $value,
   $fact      = $name,
   $file      = 'facts.txt',
-  $facts_dir = '/etc/facter/facts.d',
+  $facts_dir = '/etc/facter/facts.d/',
 ) {
 
   include ::facter

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,6 +86,10 @@ class facter (
       recurse => $purge_facts_d_real,
       require => Exec["mkdir_p-${facts_d_dir}"],
     }
+
+    File{
+      require => File['facts_d_directory'],
+    }
   }
 
   if is_string($ensure_facter_symlink) {
@@ -112,7 +116,6 @@ class facter (
     owner   => $facts_file_owner,
     group   => $facts_file_group,
     mode    => $facts_file_mode,
-    require => File['facts_d_directory'],
   }
 
   # optionally push fact to client

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,25 +3,25 @@
 # Manage facter
 #
 class facter (
-  $manage_package         = true,
-  $package_name           = 'facter',
-  $package_ensure         = 'present',
-  $manage_facts_d_dir     = true,
-  $purge_facts_d          = false,
-  $facts_d_dir            = '/etc/facter/facts.d',
-  $facts_d_owner          = 'root',
-  $facts_d_group          = 'root',
-  $facts_d_mode           = '0755',
-  $path_to_facter         = '/usr/bin/facter',
-  $path_to_facter_symlink = '/usr/local/bin/facter',
-  $ensure_facter_symlink  = false,
-  $facts_hash             = {},
-  $facts_hash_hiera_merge = false,
-  $facts_file             = 'facts.txt',
-  $facts_file_owner       = 'root',
-  $facts_file_group       = 'root',
-  $facts_file_mode        = '0644',
-) {
+  $manage_package         = $facter::params::manage_package,
+  $package_name           = $facter::params::package_name,
+  $package_ensure         = $facter::params::package_ensure,
+  $manage_facts_d_dir     = $facter::params::manage_facts_d_dir,
+  $purge_facts_d          = $facter::params::purge_facts_d,
+  $facts_d_dir            = $facter::params::facts_d_dir,
+  $facts_d_owner          = $facter::params::facts_d_owner,
+  $facts_d_group          = $facter::params::facts_d_group,
+  $facts_d_mode           = $facter::params::facts_d_mode,
+  $path_to_facter         = $facter::params::path_to_facter,
+  $path_to_facter_symlink = $facter::params::path_to_facter_symlink,
+  $ensure_facter_symlink  = $facter::params::ensure_facter_symlink,
+  $facts_hash             = $facter::params::facts_hash,
+  $facts_hash_hiera_merge = $facter::params::facts_hash_hiera_merge,
+  $facts_file             = $facter::params::facts_file,
+  $facts_file_owner       = $facter::params::facts_file_owner,
+  $facts_file_group       = $facter::params::facts_file_group,
+  $facts_file_mode        = $facter::params::facts_file_mode,
+) inherits facter::params {
 
   validate_string($package_ensure)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,40 @@
+class facter::params(
+){
+
+  $facts_file             = 'facts.txt'
+  $facts_d_mode           = '0755'
+  $facts_file_mode        = '0644'
+  $package_ensure         = 'present'
+  $manage_package         = true
+  $manage_facts_d_dir     = true
+  $purge_facts_d          = false
+  $ensure_facter_symlink  = false
+  $facts_hash             = {}
+  $facts_hash_hiera_merge = false
+  $path_to_facter_symlink = '/usr/local/bin/facter'
+
+  case $::kernel {
+    'Linux': {
+      $facts_d_dir            = '/etc/facter/facts.d'
+      $path_to_facter         = '/usr/bin/facter'
+      $facts_d_owner          = 'root'
+      $facts_d_group          = 'root'
+      $facts_file_owner       = 'root'
+      $facts_file_group       = 'root'
+      $package_name           = 'facter'
+    }
+    'windows': {
+      $facts_d_dir            = 'C:/ProgramData/PuppetLabs/facter/facts.d'
+      $path_to_facter         = 'C:/Program Files/Puppet Labs/Puppet/bin/facter.bat'
+      $facts_d_owner          = 'administrator'
+      $facts_d_group          = 'administrator'
+      $facts_file_owner       = 'administrator'
+      $facts_file_group       = 'administrator'
+      $package_name           = 'facter'
+    }
+    default: {
+      fail("${::kernel} not supported")
+    }
+  }
+
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,10 +26,10 @@ class facter::params(
     'windows': {
       $facts_d_dir            = 'C:/ProgramData/PuppetLabs/facter/facts.d'
       $path_to_facter         = 'C:/Program Files/Puppet Labs/Puppet/bin/facter.bat'
-      $facts_d_owner          = 'administrator'
-      $facts_d_group          = 'administrator'
-      $facts_file_owner       = 'administrator'
-      $facts_file_group       = 'administrator'
+      $facts_d_owner          = 'BUILTIN\Administrators'
+      $facts_d_group          = 'BUILTIN\Administrators'
+      $facts_file_owner       = 'BUILTIN\Administrators'
+      $facts_file_group       = 'BUILTIN\Administrators'
       $package_name           = 'facter'
     }
     default: {


### PR DESCRIPTION
This PR add support for windows (Using a param.pp)

It also fixes a small issue when you set `manage_facts_d_dir ` to false
Since the facts_file requires the directory.