### PR TITLE
Support Puppet 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,16 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 4.10.0"
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.0.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.1.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.2.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.3.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5"
 
 notifications:
   email: false

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -15,12 +15,11 @@ define facter::fact (
 
   if $file != $facter::facts_file {
     file { "facts_file_${name}":
-      ensure  => file,
-      path    => "${facts_dir}/${file}",
-      owner   => $facter::facts_file_owner,
-      group   => $facter::facts_file_group,
-      mode    => $facter::facts_file_mode,
-      require => File['facts_d_directory'],
+      ensure => file,
+      path   => "${facts_dir}/${file}",
+      owner  => $facter::facts_file_owner,
+      group  => $facter::facts_file_group,
+      mode   => $facter::facts_file_mode,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,7 @@ class facter (
   validate_absolute_path($path_to_facter_symlink)
   validate_absolute_path($path_to_facter)
 
-  if $::puppetversion =~ /^4/ {
+  if versioncmp($::puppetversion, '4.0.0') >= 0 {
     $manage_package_real = false
   } elsif $manage_package == undef {
     $manage_package_real = true
@@ -115,12 +115,11 @@ class facter (
 
   validate_absolute_path("${facts_d_dir}/${facts_file}")
   file { 'facts_file':
-    ensure  => file,
-    path    => "${facts_d_dir}/${facts_file}",
-    owner   => $facts_file_owner,
-    group   => $facts_file_group,
-    mode    => $facts_file_mode,
-    require => File['facts_d_directory'],
+    ensure => file,
+    path   => "${facts_d_dir}/${facts_file}",
+    owner  => $facts_file_owner,
+    group  => $facts_file_group,
+    mode   => $facts_file_mode,
   }
 
   # optionally push fact to client

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -21,7 +21,6 @@ describe 'facter' do
         'owner'   => 'root',
         'group'   => 'root',
         'mode'    => '0644',
-        'require' => 'File[facts_d_directory]',
       })
     }
 
@@ -92,6 +91,17 @@ describe 'facter' do
         expect {
           should contain_class('facter')
         }.to raise_error(Puppet::Error,/\["invalid", "type"\] is not a boolean/)
+      end
+    end
+  end
+
+  describe 'on puppet5 the package should not be managed' do
+    let(:facts) { { :puppetversion => '5.3.0' } }
+    [true,false].each do |value|
+      context "with manage_package set to #{value}" do
+        let(:params) { { :manage_package => value } }
+
+        it { should_not contain_package('facter') }
       end
     end
   end
@@ -266,7 +276,6 @@ describe 'facter' do
         'owner'   => 'root',
         'group'   => 'root',
         'mode'    => '0644',
-        'require' => 'File[facts_d_directory]',
       })
     }
 
@@ -314,7 +323,6 @@ describe 'facter' do
         'owner'   => 'root',
         'group'   => 'root',
         'mode'    => '0644',
-        'require' => 'File[facts_d_directory]',
       })
     }
 
@@ -324,7 +332,6 @@ describe 'facter' do
         'owner'   => 'root',
         'group'   => 'root',
         'mode'    => '0644',
-        'require' => 'File[facts_d_directory]',
       })
     }
 
@@ -334,7 +341,6 @@ describe 'facter' do
         'owner'   => 'root',
         'group'   => 'root',
         'mode'    => '0644',
-        'require' => 'File[facts_d_directory]',
       })
     }
 
@@ -415,7 +421,6 @@ describe 'facter' do
         'owner'   => 'puppet',
         'group'   => 'puppet',
         'mode'    => '0775',
-        'require' => 'File[facts_d_directory]',
       })
     }
 

--- a/spec/defines/fact_spec.rb
+++ b/spec/defines/fact_spec.rb
@@ -19,7 +19,6 @@ describe 'facter::fact' do
         'owner'   => 'root',
         'group'   => 'root',
         'mode'    => '0644',
-        'require' => 'File[facts_d_directory]',
       })
     }
 


### PR DESCRIPTION
Rely on fact that Puppet autorequires a files parent directory as manage_facts_d_dir=false caused compilation errors in Puppet 5 when require was set to that non-existant resource.

Initial Puppet 5 support, backwards compatible.