### PR TITLE
Drop Puppet 3 support.  Use data types for parameters

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   repositories:
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '4.6.0'
+      ref: '4.22.0'
   symlinks:
     facter: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,27 +15,11 @@ before_install:
 
 sudo: false
 
-script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
+script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec strings:generate'
 
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4"
   - rvm: 2.4.1

--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,7 @@ gem 'metadata-json-lint' if RUBY_VERSION >= '2.0'
 gem 'puppetlabs_spec_helper', '2.0.2',    :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false if RUBY_VERSION >= '1.9'
 gem 'parallel_tests',         '<= 2.9.0', :require => false if RUBY_VERSION < '2.0.0'
+
+group :documentation do
+  gem 'puppet-strings', require: false
+end

--- a/Rakefile
+++ b/Rakefile
@@ -3,9 +3,9 @@ require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.relative = true
-PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp', 'vendor/**/*.pp']
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vendor/**/*.pp"]
 
-desc 'Validate manifests, templates, ruby files and shell scripts'
+desc 'Validate manifests, templates, and ruby files'
 task :validate do
   Dir['spec/**/*.rb', 'lib/**/*.rb'].each do |ruby_file|
     sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
@@ -14,3 +14,10 @@ task :validate do
     sh "bash -n #{shell_script}"
   end
 end
+
+# Puppet Strings (Documentation generation from inline comments)
+# See: https://github.com/puppetlabs/puppet-strings#rake-tasks
+require 'puppet-strings/tasks'
+
+desc 'Alias for strings:generate'
+task :doc => ['strings:generate']

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -4,9 +4,9 @@
 #
 define facter::fact (
   $value,
-  $fact      = $name,
-  $file      = 'facts.txt',
-  $facts_dir = '/etc/facter/facts.d',
+  String $fact                    = $name,
+  String $file                    = 'facts.txt',
+  Stdlib::Absolutepath $facts_dir = '/etc/facter/facts.d',
 ) {
 
   include ::facter

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,81 +3,24 @@
 # Manage facter
 #
 class facter (
-  $manage_package         = undef,
-  $package_name           = 'facter',
-  $package_ensure         = 'present',
-  $manage_facts_d_dir     = true,
-  $purge_facts_d          = false,
-  $facts_d_dir            = '/etc/facter/facts.d',
-  $facts_d_owner          = 'root',
-  $facts_d_group          = 'root',
-  $facts_d_mode           = '0755',
-  $path_to_facter         = '/usr/bin/facter',
-  $path_to_facter_symlink = '/usr/local/bin/facter',
-  $ensure_facter_symlink  = false,
-  $facts_hash             = {},
-  $facts_hash_hiera_merge = false,
-  $facts_file             = 'facts.txt',
-  $facts_file_owner       = 'root',
-  $facts_file_group       = 'root',
-  $facts_file_mode        = '0644',
+  Boolean $manage_facts_d_dir                   = true,
+  Boolean $purge_facts_d                        = false,
+  Stdlib::Absolutepath $facts_d_dir             = '/etc/facter/facts.d',
+  String $facts_d_owner                         = 'root',
+  String $facts_d_group                         = 'root',
+  Stdlib::Filemode $facts_d_mode                = '0755',
+  Stdlib::Absolutepath $path_to_facter          = '/opt/puppetlabs/bin/facter',
+  Stdlib::Absolutepath $path_to_facter_symlink  = '/usr/local/bin/facter',
+  Boolean $ensure_facter_symlink                = false,
+  Hash $facts_hash                              = {},
+  Boolean $facts_hash_hiera_merge               = false,
+  String $facts_file                            = 'facts.txt',
+  String $facts_file_owner                      = 'root',
+  String $facts_file_group                      = 'root',
+  Stdlib::Filemode $facts_file_mode             = '0644',
 ) {
 
-  validate_string($package_ensure)
-
-  validate_absolute_path($facts_d_dir)
-
-  validate_re($facts_d_mode,
-    '^\d{4}$',
-    "facter::facts_d_mode must be a four digit mode. Detected value is <${facts_d_mode}>."
-  )
-
-  # validate params
-  validate_absolute_path($path_to_facter_symlink)
-  validate_absolute_path($path_to_facter)
-
-  if versioncmp($::puppetversion, '4.0.0') >= 0 {
-    $manage_package_real = false
-  } elsif $manage_package == undef {
-    $manage_package_real = true
-  } else {
-    $manage_package_real = $manage_package
-  }
-
-  if is_string($manage_package_real) {
-    $manage_package_bool = str2bool($manage_package_real)
-  } else {
-    $manage_package_bool = $manage_package_real
-    validate_bool($manage_package_bool)
-  }
-
-  if is_string($manage_facts_d_dir) {
-    $manage_facts_d_dir_real = str2bool($manage_facts_d_dir)
-  } else {
-    validate_bool($manage_facts_d_dir)
-    $manage_facts_d_dir_real = $manage_facts_d_dir
-  }
-
-  if is_string($purge_facts_d) {
-    $purge_facts_d_real = str2bool($purge_facts_d)
-  } else {
-    $purge_facts_d_real = $purge_facts_d
-  }
-  validate_bool($purge_facts_d_real)
-
-  if !is_string($package_name) and !is_array($package_name) {
-    fail('facter::package_name must be a string or an array.')
-  }
-
-  if $manage_package_bool == true {
-
-    package { $package_name:
-      ensure => $package_ensure,
-    }
-  }
-
-  if $manage_facts_d_dir_real == true {
-
+  if $manage_facts_d_dir == true {
     exec { "mkdir_p-${facts_d_dir}":
       command => "mkdir -p ${facts_d_dir}",
       unless  => "test -d ${facts_d_dir}",
@@ -90,22 +33,14 @@ class facter (
       owner   => $facts_d_owner,
       group   => $facts_d_group,
       mode    => $facts_d_mode,
-      purge   => $purge_facts_d_real,
-      recurse => $purge_facts_d_real,
+      purge   => $purge_facts_d,
+      recurse => $purge_facts_d,
       require => Exec["mkdir_p-${facts_d_dir}"],
     }
   }
 
-  if is_string($ensure_facter_symlink) {
-    $ensure_facter_symlink_bool = str2bool($ensure_facter_symlink)
-  } else {
-    $ensure_facter_symlink_bool = $ensure_facter_symlink
-  }
-  validate_bool($ensure_facter_symlink_bool)
-
   # optionally create symlinks to facter binary
-  if $ensure_facter_symlink_bool == true {
-
+  if $ensure_facter_symlink == true {
     file { 'facter_symlink':
       ensure => 'link',
       path   => $path_to_facter_symlink,
@@ -113,7 +48,6 @@ class facter (
     }
   }
 
-  validate_absolute_path("${facts_d_dir}/${facts_file}")
   file { 'facts_file':
     ensure => file,
     path   => "${facts_d_dir}/${facts_file}",
@@ -122,21 +56,12 @@ class facter (
     mode   => $facts_file_mode,
   }
 
-  # optionally push fact to client
-  if is_string($facts_hash_hiera_merge) {
-    $facts_hash_hiera_merge_real = str2bool($facts_hash_hiera_merge)
-  } else {
-    $facts_hash_hiera_merge_real = $facts_hash_hiera_merge
-  }
-  validate_bool($facts_hash_hiera_merge_real)
-
-  if $facts_hash_hiera_merge_real == true {
+  if $facts_hash_hiera_merge == true {
     $facts_hash_real = hiera_hash('facter::facts_hash', {})
   } else {
     $facts_hash_real = $facts_hash
   }
 
-  validate_hash($facts_hash_real)
   if ! empty( $facts_hash_real ) {
     $facts_defaults = {
       'file'      => $facts_file,

--- a/metadata.json
+++ b/metadata.json
@@ -10,10 +10,10 @@
   "issues_url": "https://github.com/ghoneycutt/puppet-module-facter/issues",
   "description": "Manage Facter and optionally ensure facts.d directory.",
   "requirements": [
-    {"name":"puppet","version_requirement":">= 3.0.0 < 6.0.0"}
+    {"name":"puppet","version_requirement":">= 4.7.0 < 6.0.0"}
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.22.0 < 6.0.0"}
   ],
   "operatingsystem_support": [
     {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,13 +8,6 @@ describe 'facter' do
 
     it { should contain_class('facter') }
 
-    it {
-      should contain_package('facter').with({
-        'ensure' => 'present',
-        'name'   => 'facter',
-      })
-    }
-
     it { should contain_file('facts_file').with({
         'ensure'  => 'file',
         'path'    => '/etc/facter/facts.d/facts.txt',
@@ -46,148 +39,45 @@ describe 'facter' do
   end
 
   describe 'with purge_facts_d' do
-    ['true',true].each do |value|
-      context "set to #{value}" do
-        let(:params) { { :purge_facts_d => value } }
-        let(:facts) { { :osfamily => 'RedHat' } }
+    context "set to true" do
+      let(:params) { { :purge_facts_d => true } }
+      let(:facts) { { :osfamily => 'RedHat' } }
 
-        it {
-          should contain_file('facts_d_directory').with({
-            'ensure'  => 'directory',
-            'path'    => '/etc/facter/facts.d',
-            'owner'   => 'root',
-            'group'   => 'root',
-            'mode'    => '0755',
-            'purge'   => true,
-            'recurse' => true,
-            'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
-          })
-        }
-      end
+      it {
+        should contain_file('facts_d_directory').with({
+          'ensure'  => 'directory',
+          'path'    => '/etc/facter/facts.d',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0755',
+          'purge'   => true,
+          'recurse' => true,
+          'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
+        })
+      }
     end
-    ['false',false].each do |value|
-      context "set to #{value}" do
-        let(:params) { { :purge_facts_d => value } }
-        let(:facts) { { :osfamily => 'RedHat' } }
+    context "set to false" do
+      let(:params) { { :purge_facts_d => false } }
+      let(:facts) { { :osfamily => 'RedHat' } }
 
-        it {
-          should contain_file('facts_d_directory').with({
-            'ensure'  => 'directory',
-            'path'    => '/etc/facter/facts.d',
-            'owner'   => 'root',
-            'group'   => 'root',
-            'mode'    => '0755',
-            'purge'   => false,
-            'recurse' => false,
-            'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
-          })
-        }
-      end
-    end
-    context 'set to an invalid type' do
-      let(:params) { { :purge_facts_d => ['invalid', 'type'] } }
-
-      it do
-        expect {
-          should contain_class('facter')
-        }.to raise_error(Puppet::Error,/\["invalid", "type"\] is not a boolean/)
-      end
+      it {
+        should contain_file('facts_d_directory').with({
+          'ensure'  => 'directory',
+          'path'    => '/etc/facter/facts.d',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0755',
+          'purge'   => false,
+          'recurse' => false,
+          'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
+        })
+      }
     end
   end
 
-  describe 'on puppet5 the package should not be managed' do
-    let(:facts) { { :puppetversion => '5.3.0' } }
-    [true,false].each do |value|
-      context "with manage_package set to #{value}" do
-        let(:params) { { :manage_package => value } }
-
-        it { should_not contain_package('facter') }
-      end
-    end
-  end
-
-  describe 'on puppet4 the package should not be managed' do
-    let(:facts) { { :puppetversion => '4.10.0' } }
-    [true,false].each do |value|
-      context "with manage_package set to #{value}" do
-        let(:params) { { :manage_package => value } }
-
-        it { should_not contain_package('facter') }
-      end
-    end
-  end
-
-  context 'with default options and stringified \'true\' for manage_package param' do
-    let(:params) { { :manage_package => 'true' } }
-    let(:facts) { { :osfamily => 'RedHat' } }
-
-    it { should contain_class('facter') }
-
-    it {
-      should contain_package('facter').with({
-        'ensure' => 'present',
-        'name'   => 'facter',
-      })
-    }
-
-    it {
-      should contain_file('facts_d_directory').with({
-        'ensure'  => 'directory',
-        'path'    => '/etc/facter/facts.d',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0755',
-        'purge'   => false,
-        'recurse' => false,
-        'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
-      })
-    }
-
-    it {
-      should contain_exec('mkdir_p-/etc/facter/facts.d').with({
-        'command' => 'mkdir -p /etc/facter/facts.d',
-        'unless'  => 'test -d /etc/facter/facts.d',
-      })
-    }
-  end
-
-  context 'with default options and stringified \'true\' for manage_facts_d_dir param' do
-    let(:params) { { :manage_facts_d_dir => 'true' } }
-    let(:facts) { { :osfamily => 'RedHat' } }
-
-    it { should contain_class('facter') }
-
-    it {
-      should contain_package('facter').with({
-        'ensure' => 'present',
-        'name'   => 'facter',
-      })
-    }
-
-    it {
-      should contain_file('facts_d_directory').with({
-        'ensure'  => 'directory',
-        'path'    => '/etc/facter/facts.d',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0755',
-        'purge'   => false,
-        'recurse' => false,
-        'require' => 'Exec[mkdir_p-/etc/facter/facts.d]',
-      })
-    }
-
-    it {
-      should contain_exec('mkdir_p-/etc/facter/facts.d').with({
-        'command' => 'mkdir -p /etc/facter/facts.d',
-        'unless'  => 'test -d /etc/facter/facts.d',
-      })
-    }
-  end
-
-  context 'with default options with manage_package = true and manage_facts_d_dir = false' do
+  context 'with manage_facts_d_dir = false' do
     let(:params) do
-      { :manage_package     => true,
+      {
         :manage_facts_d_dir => false,
       }
     end
@@ -195,29 +85,20 @@ describe 'facter' do
 
     it { should contain_class('facter') }
 
-    it {
-      should contain_package('facter').with({
-        'ensure' => 'present',
-        'name'   => 'facter',
-      })
-    }
-
     it { should_not contain_file('facts_d_directory') }
 
     it { should_not contain_exec('mkdir_p-/etc/facter/facts.d') }
   end
 
-  context 'with default options with manage_package = false and manage_facts_d_dir = true' do
+  context 'with manage_facts_d_dir = true' do
     let(:params) do
-      { :manage_package     => false,
+      {
         :manage_facts_d_dir => true,
       }
     end
     let(:facts) { { :osfamily => 'RedHat' } }
 
     it { should contain_class('facter') }
-
-    it { should_not contain_package('facter') }
 
     it {
       should contain_file('facts_d_directory').with({
@@ -236,23 +117,6 @@ describe 'facter' do
         'unless'  => 'test -d /etc/facter/facts.d',
       })
     }
-  end
-
-  context 'with default options with manage_package = false and manage_facts_d_dir = false' do
-    let(:params) do
-      { :manage_package     => false,
-        :manage_facts_d_dir => false,
-      }
-    end
-    let(:facts) { { :osfamily => 'RedHat' } }
-
-    it { should contain_class('facter') }
-
-    it { should_not contain_package('facter') }
-
-    it { should_not contain_file('facts_d_directory') }
-
-    it { should_not contain_exec('mkdir_p-/etc/facter/facts.d') }
   end
 
   context 'with facts specified as a hash on RedHat' do
@@ -369,8 +233,7 @@ describe 'facter' do
   context 'with all options specified' do
     let(:facts) { { :osfamily => 'RedHat' } }
     let(:params) do
-      { :package_name     => 'myfacter',
-        :package_ensure   => 'absent',
+      {
         :facts_d_dir      => '/etc/puppet/facter/facts.d',
         :facts_d_owner    => 'puppet',
         :facts_d_group    => 'puppet',
@@ -388,12 +251,6 @@ describe 'facter' do
     end
 
     it { should contain_class('facter') }
-
-    it {
-      should contain_package('myfacter').with({
-        'ensure' => 'absent',
-      })
-    }
 
     it {
       should contain_file('facts_d_directory').with({
@@ -431,73 +288,6 @@ describe 'facter' do
     }
   end
 
-  describe 'with package_name set to' do
-    context 'a string' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :package_name => 'myfacter' } }
-
-      it {
-        should contain_package('myfacter').with({
-          'ensure' => 'present',
-        })
-      }
-    end
-
-    context 'an array' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :package_name => ['facter','facterfoo'] } }
-
-      it {
-        should contain_package('facter').with({
-          'ensure' => 'present',
-        })
-      }
-
-      it {
-        should contain_package('facterfoo').with({
-          'ensure' => 'present',
-        })
-      }
-    end
-
-    context 'an invalid type (boolean)' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :package_name => true } }
-
-      it do
-        expect {
-          should contain_class('facter')
-        }.to raise_error(Puppet::Error,/facter::package_name must be a string or an array./)
-      end
-    end
-  end
-
-  describe 'with package_ensure parameter' do
-    ['present','absent','23'].each do |value|
-      context "set to a valid string value of #{value}" do
-        let(:facts) { { :osfamily => 'RedHat' } }
-        let(:params) { { :package_ensure => value } }
-
-        it {
-          should contain_package('facter').with({
-            'ensure' => value,
-          })
-        }
-      end
-    end
-
-    context 'set to a non-string value' do
-      let(:facts) { { :osfamily => 'RedHat' } }
-      let(:params) { { :package_ensure => ['invalid'] } }
-
-      it do
-        expect {
-          should contain_class('facter')
-        }.to raise_error(Puppet::Error)
-      end
-    end
-  end
-
   context 'with invalid facts_d_dir param' do
     let(:facts) { { :osfamily => 'RedHat' } }
     let(:params) { { :facts_d_dir => 'invalid/path/statement' } }
@@ -516,7 +306,7 @@ describe 'facter' do
     it do
       expect {
         should contain_class('facter')
-      }.to raise_error(Puppet::Error,/facter::facts_d_mode must be a four digit mode. Detected value is <751>./)
+      }.to raise_error(Puppet::Error,/Pattern\[\/\^\[0124\]\{1\}\[0-7\]\{3\}\$\/\]/)
     end
   end
 
@@ -543,28 +333,24 @@ describe 'facter' do
   end
 
   describe 'with ensure_facter_symlink' do
-    ['true',true].each do |value|
-      context "set to #{value} (default)" do
-        let(:facts) { { :osfamily => 'Debian' } }
-        let(:params) { { :ensure_facter_symlink => value } }
+    context "set to true (default)" do
+      let(:facts) { { :osfamily => 'Debian' } }
+      let(:params) { { :ensure_facter_symlink => true } }
 
-        it {
-          should contain_file('facter_symlink').with({
-            'ensure'  => 'link',
-            'path'    => '/usr/local/bin/facter',
-            'target'  => '/usr/bin/facter',
-          })
-        }
-      end
+      it {
+        should contain_file('facter_symlink').with({
+          'ensure'  => 'link',
+          'path'    => '/usr/local/bin/facter',
+          'target'  => '/opt/puppetlabs/bin/facter',
+        })
+      }
     end
 
-    ['false',false].each do |value|
-      context "set to #{value} (default)" do
-        let(:facts) { { :osfamily => 'Debian' } }
-        let(:params) { { :ensure_facter_symlink => value } }
+    context "set to false (default)" do
+      let(:facts) { { :osfamily => 'Debian' } }
+      let(:params) { { :ensure_facter_symlink => false } }
 
-        it { should_not contain_file('facter_symlink') }
-      end
+      it { should_not contain_file('facter_symlink') }
     end
 
     context 'enabled with all params specified' do
@@ -646,50 +432,6 @@ describe 'facter' do
         :parameter_tests => 'facts_hash_hiera_merge',
       }
     end
-
-    context 'set to valid value true' do
-      let(:params) { { :facts_hash_hiera_merge => 'true' } }
-
-      it { should have_facter__fact_resource_count(2) }
-      it do
-        should contain_facter__fact('role').with({
-          'file'      => 'facts.txt',
-          'facts_dir' => '/etc/facter/facts.d',
-          'value'     => 'puppetmaster',
-        })
-      end
-      it do
-        should contain_facter__fact('location').with({
-          'file'      => 'location.txt',
-          'facts_dir' => '/etc/facter/facts.d',
-          'value'     => 'RNB',
-        })
-      end
-    end
-
-    context 'set to valid value false' do
-      let(:params) { { :facts_hash_hiera_merge => 'false' } }
-
-      it { should have_facter__fact_resource_count(1) }
-      it do
-        should contain_facter__fact('role').with({
-          'file'      => 'facts.txt',
-          'facts_dir' => '/etc/facter/facts.d',
-          'value'     => 'puppetmaster',
-        })
-      end
-      it { should_not contain_facter__fact('location') }
-    end
-
-    context 'set to invalid value <invalid>' do
-      let(:params) { { :facts_hash_hiera_merge => 'invalid' } }
-
-      it 'should fail' do
-        expect {
-          should contain_class('facter')
-        }.to raise_error(Puppet::Error,/str2bool\(\): Unknown type of boolean given at/)
-      end
-    end
   end
 
   describe 'variable type and content validations' do
@@ -706,11 +448,11 @@ describe 'facter' do
     end
 
     validations = {
-      'bool_stringified' => {
-        :name    => %w(facts_hash_hiera_merge),
-        :valid   => [true, 'true', false, 'false'],
-        :invalid => ['invalid', 3, 2.42, %w(array), { 'ha' => 'sh' }, nil],
-        :message => '(is not a boolean|Unknown type of boolean)',
+      'boolean' => {
+        :name    => %w(facts_hash_hiera_merge purge_facts_d),
+        :valid   => [true, false],
+        :invalid => ['invalid', 'true', 'false', 3, 2.42, %w(array), { 'ha' => 'sh' }, nil],
+        :message => 'expects a Boolean value',
       },
     }
 


### PR DESCRIPTION
Similar operations to what was done to PAM module.

Relates to #57 and #52 