### PR TITLE
Add facts_file_purge parameter to use concat

### DIFF
--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -2,3 +2,5 @@ fixtures:
   repositories:
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    concat:
+      repo: 'https://github.com/puppetlabs/puppetlabs-concat.git'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,3 +3,6 @@ fixtures:
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
       ref: '4.22.0'
+    concat:
+      repo: 'https://github.com/puppetlabs/puppetlabs-concat.git'
+      ref: '4.0.0'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,4 +5,4 @@ fixtures:
       ref: '4.22.0'
     concat:
       repo: 'https://github.com/puppetlabs/puppetlabs-concat.git'
-      ref: '4.0.0'
+      ref: 'v6.0.0'

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -34,18 +34,38 @@ define facter::fact (
   $match = "^${name}=\\S.*$"
 
   if $facts_file != $facter::facts_file {
-    file { "facts_file_${name}":
-      ensure => file,
-      path   => $facts_file_path,
-      owner  => $facter::facts_file_owner,
-      group  => $facter::facts_file_group,
-      mode   => $facter::facts_file_mode,
+    if $facter::facts_file_purge {
+      $concat_target = "facts_file_${name}"
+      concat { "facts_file_${name}":
+        ensure => 'present',
+        path   => $facts_file_path,
+        owner  => $facter::facts_file_owner,
+        group  => $facter::facts_file_group,
+        mode   => $facter::facts_file_mode,
+      }
+    } else {
+      file { "facts_file_${name}":
+        ensure => file,
+        path   => $facts_file_path,
+        owner  => $facter::facts_file_owner,
+        group  => $facter::facts_file_group,
+        mode   => $facter::facts_file_mode,
+      }
     }
+  } else {
+    $concat_target = 'facts_file'
   }
 
-  file_line { "fact_line_${name}":
-    path  => $facts_file_path,
-    line  => "${name}=${value}",
-    match => $match,
+  if $facter::facts_file_purge {
+    concat::fragment { "fact_line_${name}":
+      target  => $concat_target,
+      content => "${name}=${value}",
+    }
+  } else {
+    file_line { "fact_line_${name}":
+      path  => $facts_file_path,
+      line  => "${name}=${value}",
+      match => $match,
+    }
   }
 }

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -34,38 +34,20 @@ define facter::fact (
   $match = "^${name}=\\S.*$"
 
   if $facts_file != $facter::facts_file {
-    if $facter::facts_file_purge {
-      $concat_target = "facts_file_${name}"
-      concat { "facts_file_${name}":
-        ensure => 'present',
-        path   => $facts_file_path,
-        owner  => $facter::facts_file_owner,
-        group  => $facter::facts_file_group,
-        mode   => $facter::facts_file_mode,
-      }
-    } else {
-      file { "facts_file_${name}":
-        ensure => file,
-        path   => $facts_file_path,
-        owner  => $facter::facts_file_owner,
-        group  => $facter::facts_file_group,
-        mode   => $facter::facts_file_mode,
-      }
+    $concat_target = "facts_file_${name}"
+    concat { "facts_file_${name}":
+      ensure => 'present',
+      path   => $facts_file_path,
+      owner  => $facter::facts_file_owner,
+      group  => $facter::facts_file_group,
+      mode   => $facter::facts_file_mode,
     }
   } else {
     $concat_target = 'facts_file'
   }
 
-  if $facter::facts_file_purge {
-    concat::fragment { "fact_line_${name}":
-      target  => $concat_target,
-      content => "${name}=${value}",
-    }
-  } else {
-    file_line { "fact_line_${name}":
-      path  => $facts_file_path,
-      line  => "${name}=${value}",
-      match => $match,
-    }
+  concat::fragment { "fact_line_${name}":
+    target  => $concat_target,
+    content => "${name}=${value}",
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.22.0 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 4.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/facter_spec.rb
+++ b/spec/acceptance/facter_spec.rb
@@ -79,7 +79,7 @@ describe 'facter class' do
         if host_inventory['platform'] != 'windows'
           it { should be_grouped_into facts_file_group }
           it { should be_mode facts_file_mode }
-          its(:size) { should eq 0 }
+          its(:size) { should eq 38 }
         end
       end
     end
@@ -128,7 +128,7 @@ describe 'facter class' do
     end
   end
 
-  context 'with specify facts_file_purge as true' do
+  context 'purges unmanaged facts' do
     context 'should apply the manifest' do
       setup_pp = <<-EOS
       class { 'facter':
@@ -141,8 +141,7 @@ describe 'facter class' do
       EOS
       pp = <<-EOS
       class { 'facter':
-        facts_file_purge => true,
-        facts_hash       => {
+        facts_hash => {
           'test2_fact' => {
             value => 'test2_value',
           },
@@ -178,11 +177,11 @@ describe 'facter class' do
     end
 
     context 'and should remove facts not managed by puppet' do
-      describe command('facter -p test1_fact') do
-        its(:stdout) { should_not contain('test1_value') }
+      describe file(facts_file) do
+        its(:content) { should_not match %r{test1_fact=.*} }
       end
-      describe command('facter -p test2_fact') do
-        its(:stdout) { should contain('test2_value') }
+      describe file(facts_file) do
+        its(:content) { should match %r{test2_fact=.*} }
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -30,6 +30,7 @@ describe 'facter' do
             'mode'    => '0644',
           })
         }
+        it { should_not contain_concat('facts_file') }
 
         it {
           should contain_file('facts_d_directory').with({
@@ -369,6 +370,23 @@ describe 'facter' do
         }
       end
 
+      context 'with facts_file_purge' do
+        let(:params) { { :facts_file_purge => true } }
+
+        it {
+          should contain_concat('facts_file').with({
+            'ensure'         => 'present',
+            'path'           => '/etc/facter/facts.d/facts.txt',
+            'owner'          => 'root',
+            'group'          => 'root',
+            'mode'           => '0644',
+            'ensure_newline' => 'true',
+            'require'        => 'File[facts_d_directory]',
+          })
+        }
+        it { should_not contain_file('facts_file') }
+      end # context 'with facts_file_purge'
+
       describe 'variable type and content validations' do
         # set needed custom facts and variables
         let(:facts) do
@@ -470,6 +488,8 @@ describe 'facter' do
             'mode'    => nil,
           })
         }
+
+        it { should_not contain_concat('facts_file') }
 
         it {
           should contain_file('facts_d_directory').with({
@@ -610,6 +630,22 @@ describe 'facter' do
           })
         }
       end # context 'with all options specified'
+
+      context 'with facts_file_purge' do
+        let(:params) { { :facts_file_purge => true } }
+
+        it {
+          should contain_concat('facts_file').with({
+            'ensure'         => 'present',
+            'path'           => 'C:\ProgramData\PuppetLabs\facter\facts.d\facts.txt',
+            'owner'          => 'NT AUTHORITY\SYSTEM',
+            'group'          => 'NT AUTHORITY\SYSTEM',
+            'ensure_newline' => 'true',
+            'require'        => 'File[facts_d_directory]',
+          })
+        }
+        it { should_not contain_file('facts_file') }
+      end # context 'with facts_file_purge'
     end # on_support_os(windows)
   end # context 'on windows'
 end # describe 'facter'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,15 +22,23 @@ describe 'facter' do
         it { should contain_class('facter') }
 
         it {
-          should contain_file('facts_file').with({
-            'ensure'  => 'file',
-            'path'    => '/etc/facter/facts.d/facts.txt',
-            'owner'   => 'root',
-            'group'   => 'root',
-            'mode'    => '0644',
+          should contain_concat('facts_file').with({
+            'ensure'         => 'present',
+            'path'           => '/etc/facter/facts.d/facts.txt',
+            'owner'          => 'root',
+            'group'          => 'root',
+            'mode'           => '0644',
+            'ensure_newline' => 'true',
           })
         }
-        it { should_not contain_concat('facts_file') }
+
+        it {
+          should contain_concat__fragment('facts_file-header').with({
+            'target'  => 'facts_file',
+            'content' => "# File managed by Puppet\n#DO NOT EDIT",
+            'order'   => '00',
+          })
+        }
 
         it {
           should contain_file('facts_d_directory').with({
@@ -129,8 +137,8 @@ describe 'facter' do
         end
 
         it {
-          should contain_file('facts_file').with({
-            'ensure'  => 'file',
+          should contain_concat('facts_file').with({
+            'ensure'  => 'present',
             'path'    => '/etc/facter/facts.d/facts.txt',
             'owner'   => 'root',
             'group'   => 'root',
@@ -139,14 +147,14 @@ describe 'facter' do
         }
 
         it {
-          should contain_file_line('fact_line_fact1').with({
-            'line' => 'fact1=fact1value',
+          should contain_concat__fragment('fact_line_fact1').with({
+            'content' => 'fact1=fact1value',
           })
         }
 
         it {
-          should contain_file_line('fact_line_fact2').with({
-            'line' => 'fact2=fact2value',
+          should contain_concat__fragment('fact_line_fact2').with({
+            'content' => 'fact2=fact2value',
           })
         }
 
@@ -249,8 +257,8 @@ describe 'facter' do
         it { should contain_facter__fact('fact3') }
 
         it {
-          should contain_file('facts_file').with({
-            'ensure'  => 'file',
+          should contain_concat('facts_file').with({
+            'ensure'  => 'present',
             'path'    => '/etc/facter/facts.d/file.txt',
             'owner'   => 'root',
             'group'   => 'root',
@@ -259,8 +267,8 @@ describe 'facter' do
         }
 
         it {
-          should contain_file('facts_file_fact2').with({
-            'ensure'  => 'file',
+          should contain_concat('facts_file_fact2').with({
+            'ensure'  => 'present',
             'path'    => '/etc/facter/facts.d/file2.txt',
             'owner'   => 'root',
             'group'   => 'root',
@@ -269,8 +277,8 @@ describe 'facter' do
         }
 
         it {
-          should contain_file('facts_file_fact3').with({
-            'ensure'  => 'file',
+          should contain_concat('facts_file_fact3').with({
+            'ensure'  => 'present',
             'path'    => '/etc/facts3/file3.txt',
             'owner'   => 'root',
             'group'   => 'root',
@@ -279,20 +287,20 @@ describe 'facter' do
         }
 
         it {
-          should contain_file_line('fact_line_fact1').with({
-            'line' => 'fact1=fact1value',
+          should contain_concat__fragment('fact_line_fact1').with({
+            'content' => 'fact1=fact1value',
           })
         }
 
         it {
-          should contain_file_line('fact_line_fact2').with({
-            'line' => 'fact2=fact2value',
+          should contain_concat__fragment('fact_line_fact2').with({
+            'content' => 'fact2=fact2value',
           })
         }
 
         it {
-          should contain_file_line('fact_line_fact3').with({
-            'line' => 'fact3=fact3value',
+          should contain_concat__fragment('fact_line_fact3').with({
+            'content' => 'fact3=fact3value',
           })
         }
 
@@ -354,8 +362,8 @@ describe 'facter' do
         }
 
         it {
-          should contain_file('facts_file').with({
-            'ensure'  => 'file',
+          should contain_concat('facts_file').with({
+            'ensure'  => 'present',
             'path'    => '/etc/puppet/facter/facts.d/file.txt',
             'owner'   => 'puppet',
             'group'   => 'puppet',
@@ -364,28 +372,11 @@ describe 'facter' do
         }
 
         it {
-          should contain_file_line('fact_line_fact').with({
-            'line' => 'fact=value',
+          should contain_concat__fragment('fact_line_fact').with({
+            'content' => 'fact=value',
           })
         }
       end
-
-      context 'with facts_file_purge' do
-        let(:params) { { :facts_file_purge => true } }
-
-        it {
-          should contain_concat('facts_file').with({
-            'ensure'         => 'present',
-            'path'           => '/etc/facter/facts.d/facts.txt',
-            'owner'          => 'root',
-            'group'          => 'root',
-            'mode'           => '0644',
-            'ensure_newline' => 'true',
-            'require'        => 'File[facts_d_directory]',
-          })
-        }
-        it { should_not contain_file('facts_file') }
-      end # context 'with facts_file_purge'
 
       describe 'variable type and content validations' do
         # set needed custom facts and variables
@@ -480,16 +471,14 @@ describe 'facter' do
         it { should contain_class('facter') }
 
         it {
-          should contain_file('facts_file').with({
-            'ensure'  => 'file',
-            'path'    => 'C:\ProgramData\PuppetLabs\facter\facts.d\facts.txt',
-            'owner'   => 'NT AUTHORITY\SYSTEM',
-            'group'   => 'NT AUTHORITY\SYSTEM',
-            'mode'    => nil,
+          should contain_concat('facts_file').with({
+            'ensure'         => 'present',
+            'path'           => 'C:\ProgramData\PuppetLabs\facter\facts.d\facts.txt',
+            'owner'          => 'NT AUTHORITY\SYSTEM',
+            'group'          => 'NT AUTHORITY\SYSTEM',
+            'ensure_newline' => 'true',
           })
         }
-
-        it { should_not contain_concat('facts_file') }
 
         it {
           should contain_file('facts_d_directory').with({
@@ -615,37 +604,20 @@ describe 'facter' do
         }
 
         it {
-          should contain_file('facts_file').with({
-            'ensure'  => 'file',
+          should contain_concat('facts_file').with({
+            'ensure'  => 'present',
             'path'    => 'C:\ProgramData\PuppetLabs\facter\facts.d\file.txt',
             'owner'   => 'puppet',
             'group'   => 'puppet',
-            'mode'    => nil,
           })
         }
 
         it {
-          should contain_file_line('fact_line_fact').with({
-            'line' => 'fact=value',
+          should contain_concat__fragment('fact_line_fact').with({
+            'content' => 'fact=value',
           })
         }
       end # context 'with all options specified'
-
-      context 'with facts_file_purge' do
-        let(:params) { { :facts_file_purge => true } }
-
-        it {
-          should contain_concat('facts_file').with({
-            'ensure'         => 'present',
-            'path'           => 'C:\ProgramData\PuppetLabs\facter\facts.d\facts.txt',
-            'owner'          => 'NT AUTHORITY\SYSTEM',
-            'group'          => 'NT AUTHORITY\SYSTEM',
-            'ensure_newline' => 'true',
-            'require'        => 'File[facts_d_directory]',
-          })
-        }
-        it { should_not contain_file('facts_file') }
-      end # context 'with facts_file_purge'
     end # on_support_os(windows)
   end # context 'on windows'
 end # describe 'facter'

--- a/spec/defines/fact_spec.rb
+++ b/spec/defines/fact_spec.rb
@@ -53,6 +53,8 @@ describe 'facter::fact' do
             'match' => '^fact1=\S.*$',
           })
         }
+
+        it { should_not contain_concat__fragment('fact_line_fact1') }
       end
 
       context 'with fact specified ' do
@@ -92,6 +94,22 @@ describe 'facter::fact' do
             'match' => '^fact1=\S.*$',
           })
         }
+      end
+
+      context 'with facts_file_purge' do
+        let(:title) { 'fact1' }
+        let(:pre_condition) { "class { 'facter': facts_file_purge => true }" }
+        let(:params) { { :value => 'fact1value' } }
+
+        it { should contain_concat('facts_file') }
+        it {
+          should contain_concat__fragment('fact_line_fact1').with({
+            'target'  => 'facts_file',
+            'content' => "fact1=fact1value",
+          })
+        }
+
+        it { should_not contain_file_line('fact_line_fact1') }
       end
     end # end on_supported_os(redhat)
   end # context "on RedHat"
@@ -165,6 +183,21 @@ describe 'facter::fact' do
             'path' => 'C:\ProgramData\PuppetLabs\facter\facts.d\facts.txt',
           })
         }
+      end
+
+      context 'with facts_file_purge' do
+        let(:title) { 'fact1' }
+        let(:pre_condition) { "class { 'facter': facts_file_purge => true }" }
+        let(:params) { { :value => 'fact1value' } }
+
+        it {
+          should contain_concat__fragment('fact_line_fact1').with({
+            'target'  => 'facts_file',
+            'content' => "fact1=fact1value",
+          })
+        }
+
+        it { should_not contain_file_line('fact_line_fact1') }
       end
     end # end on_supported_os(windows)
   end # context "on windows"

--- a/spec/defines/fact_spec.rb
+++ b/spec/defines/fact_spec.rb
@@ -31,13 +31,13 @@ describe 'facter::fact' do
 
         # These must exist or the coverage report lists these incorrectly as
         # untouched resources. These resources are all from the facter class.
-        it { should contain_file('facts_file') }
+        it { should contain_concat('facts_file') }
         it { should contain_file('facts_d_directory') }
         it { should contain_exec('mkdir_p-/etc/facter/facts.d') }
 
         it {
-          should contain_file('facts_file_fact1').with({
-            'ensure'  => 'file',
+          should contain_concat('facts_file_fact1').with({
+            'ensure'  => 'present',
             'path'    => '/factsdir/custom.txt',
             'owner'   => 'root',
             'group'   => 'root',
@@ -46,15 +46,11 @@ describe 'facter::fact' do
         }
 
         it {
-          should contain_file_line('fact_line_fact1').with({
-            'name' => 'fact_line_fact1',
-            'path' => '/factsdir/custom.txt',
-            'line' => 'fact1=fact1value',
-            'match' => '^fact1=\S.*$',
+          should contain_concat__fragment('fact_line_fact1').with({
+            'target'  => 'facts_file_fact1',
+            'content' => 'fact1=fact1value',
           })
         }
-
-        it { should_not contain_concat__fragment('fact_line_fact1') }
       end
 
       context 'with fact specified ' do
@@ -68,13 +64,12 @@ describe 'facter::fact' do
 
         # Does not contain this file, because we are using the default which is
         # managed in the facter class.
-        it { should_not contain_file('facts_file_fact2') }
+        it { should_not contain_concat('facts_file_fact2') }
 
         it {
-          should contain_file_line('fact_line_fact2').with({
-            'name' => 'fact_line_fact2',
-            'line' => 'fact2=fact2value',
-            'path' => '/etc/facter/facts.d/facts.txt',
+          should contain_concat__fragment('fact_line_fact2').with({
+            'target'  => 'facts_file',
+            'content' => 'fact2=fact2value',
           })
         }
       end
@@ -89,27 +84,10 @@ describe 'facter::fact' do
         end
 
         it {
-          should contain_file_line('fact_line_fact1').with({
-            'line' => 'fact1=space in value',
-            'match' => '^fact1=\S.*$',
-          })
-        }
-      end
-
-      context 'with facts_file_purge' do
-        let(:title) { 'fact1' }
-        let(:pre_condition) { "class { 'facter': facts_file_purge => true }" }
-        let(:params) { { :value => 'fact1value' } }
-
-        it { should contain_concat('facts_file') }
-        it {
           should contain_concat__fragment('fact_line_fact1').with({
-            'target'  => 'facts_file',
-            'content' => "fact1=fact1value",
+            'content' => 'fact1=space in value',
           })
         }
-
-        it { should_not contain_file_line('fact_line_fact1') }
       end
     end # end on_supported_os(redhat)
   end # context "on RedHat"
@@ -145,8 +123,8 @@ describe 'facter::fact' do
         it { should contain_exec('mkdir_p-C:\ProgramData\PuppetLabs\facter\facts.d') }
 
         it {
-          should contain_file('facts_file_fact1').with({
-            'ensure'  => 'file',
+          should contain_concat('facts_file_fact1').with({
+            'ensure'  => 'present',
             'path'    => 'C:\factsdir\custom.txt',
             'owner'   => 'NT AUTHORITY\SYSTEM',
             'group'   => 'NT AUTHORITY\SYSTEM',
@@ -154,11 +132,9 @@ describe 'facter::fact' do
         }
 
         it {
-          should contain_file_line('fact_line_fact1').with({
-            'name' => 'fact_line_fact1',
-            'path' => 'C:\factsdir\custom.txt',
-            'line' => 'fact1=fact1value',
-            'match' => '^fact1=\S.*$',
+          should contain_concat__fragment('fact_line_fact1').with({
+            'target'  => 'facts_file_fact1',
+            'content' => 'fact1=fact1value',
           })
         }
       end
@@ -174,30 +150,13 @@ describe 'facter::fact' do
 
         # Does not contain this file, because we are using the default which is
         # managed in the facter class.
-        it { should_not contain_file('facts_file_fact2') }
+        it { should_not contain_concat('facts_file_fact2') }
 
         it {
-          should contain_file_line('fact_line_fact2').with({
-            'name' => 'fact_line_fact2',
-            'line' => 'fact2=fact2value',
-            'path' => 'C:\ProgramData\PuppetLabs\facter\facts.d\facts.txt',
+          should contain_concat__fragment('fact_line_fact2').with({
+            'content' => 'fact2=fact2value',
           })
         }
-      end
-
-      context 'with facts_file_purge' do
-        let(:title) { 'fact1' }
-        let(:pre_condition) { "class { 'facter': facts_file_purge => true }" }
-        let(:params) { { :value => 'fact1value' } }
-
-        it {
-          should contain_concat__fragment('fact_line_fact1').with({
-            'target'  => 'facts_file',
-            'content' => "fact1=fact1value",
-          })
-        }
-
-        it { should_not contain_file_line('fact_line_fact1') }
       end
     end # end on_supported_os(windows)
   end # context "on windows"


### PR DESCRIPTION
Adds `facts_file_purge` parameter that when `true` will use concat resources to manage the facts file so that unmanaged facts get purged.  This replaces #47.