### PR TITLE
allow empty fact value

### DIFF
--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -15,7 +15,7 @@
 #   default facts_d_dir.
 #
 define facter::fact (
-  String[1] $value,
+  String $value,
   String[1] $fact = $name,
   Optional[String[1]] $file = undef,
   Optional[Stdlib::Absolutepath] $facts_dir = undef,


### PR DESCRIPTION
We need to allow empty fact value, which can be set later after some puppet iterations.

Is it possible to allow empty fact values? Why is required facts to have non empty value?

Thank you.