### PR TITLE
allow file mode on windows

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,7 @@ class facter (
   if $facts['os']['family'] == 'windows' {
     $facts_file_path  = "${facts_d_dir}\\${facts_file}"
     $facts_d_mode_real = undef
-    $facts_file_mode_real = undef
+    $facts_file_mode_real = $facts_file_mode
   } else {
     $facts_file_path  = "${facts_d_dir}/${facts_file}"
     $facts_d_mode_real = $facts_d_mode


### PR DESCRIPTION
in our installation puppet wants to set file mode 0644 on windows, but it remains 0664 mode. we need to define file mode for windows too, to stop puppet to try change file mode

```
Notice: /Stage[main]/Facter/Concat[facts_file]/File[C:\ProgramData\PuppetLabs\facter\facts.d\facts.txt]/mode: mode changed '0664' to '0644'
```

thank you